### PR TITLE
Fixed typo in git prompt and added auto_complete  case in vim mode

### DIFF
--- a/prompt-git.bash
+++ b/prompt-git.bash
@@ -169,7 +169,7 @@ function ble/prompt/backslash:contrib/git-branch {
     ble/prompt/print "$ret"
   fi
 }
-function ble/prompt/backslash:contrib/git-branch {
+function ble/prompt/backslash:contrib/git-path {
   local "${_ble_contrib_prompt_git_vars[@]}"
   if ble/contrib/prompt-git/initialize; then
     if [[ $PWD == "$git_base"/?* ]]; then

--- a/prompt-vim-mode.bash
+++ b/prompt-vim-mode.bash
@@ -13,7 +13,7 @@ function ble/prompt/backslash:contrib/vim-mode {
   bleopt keymap_vi_mode_update_prompt:=1
   case $_ble_decode_keymap in
   (vi_[on]map) ble/prompt/print '(cmd)' ;;
-  (vi_imap) ble/prompt/print '(ins)' ;;
+  (vi_imap|auto_complete) ble/prompt/print '(ins)' ;;
   (vi_smap) ble/prompt/print '(sel)' ;;
   (vi_xmap) ble/prompt/print '(vis)' ;;
   esac


### PR DESCRIPTION
## Issues fixed:
* `prompt-git.bash` had a typo `git-path` instead of `git-path`
* When in `auto_complete` mode, the prompt gets wrong size since there is no case for it in `prompt-vim-mode.bash`