### PR TITLE
Allow sourcing fzf from other directories

### DIFF
--- a/fzf-completion.bash
+++ b/fzf-completion.bash
@@ -6,7 +6,9 @@ ble-import contrib/fzf-initialize
 
 # fzf/shell/completion.bash を未ロードの時のみロードする
 if ! ble/is-function _fzf_complete; then
-  if [[ -f $_ble_contrib_fzf_base/shell/completion.bash ]]; then
+  if [[ -f $_ble_contrib_fzf_base/completion.bash ]]; then
+    source "$_ble_contrib_fzf_base/completion.bash"
+  elif [[ -f $_ble_contrib_fzf_base/shell/completion.bash ]]; then
     source "$_ble_contrib_fzf_base/shell/completion.bash"
   elif [[ $_ble_contrib_fzf_base == */share/fzf && -f /etc/bash_completion.d/fzf ]]; then
     source /etc/bash_completion.d/fzf

--- a/fzf-key-bindings.bash
+++ b/fzf-key-bindings.bash
@@ -5,7 +5,11 @@ ble-import contrib/fzf-initialize
 [[ $- == *i* ]] || return 0
 
 ble/function#push bind :
-source "$_ble_contrib_fzf_base/shell/key-bindings.bash"
+if [[ -f $_ble_contrib_fzf_base/key-bindings.bash ]]; then
+  source "$_ble_contrib_fzf_base/key-bindings.bash"
+elif [[ -f $_ble_contrib_fzf_base/shell/key-bindings.bash ]]; then
+  source "$_ble_contrib_fzf_base/shell/key-bindings.bash"
+fi
 ble/function#pop bind
 
 function ble/contrib/fzf-key-bindings/is-fzf-above-7c447bbd {


### PR DESCRIPTION
Right now I am sourcing my fzf files like

```bash
source ~/.nix-profile/share/fzf/completion.bash
source ~/.nix-profile/share/fzf/key-bindings.bash
```

and with this change I can source them in `~/.blerc` like

```bash
_ble_contrib_fzf_base=$HOME/.nix-profile/share/fzf
ble-import -d contrib/fzf-completion
ble-import -d contrib/fzf-key-bindings
```