### PR TITLE
use restart, kill-timeout=0, return all group info

### DIFF
--- a/config/github302-perlre-server.bash
+++ b/config/github302-perlre-server.bash
@@ -15,17 +15,53 @@
 ble-import util.bgproc
 
 function ble/contrib/config:github302/perlre-server {
+  # We redirect 2>/dev/tty here to ensure errors show up
   exec perl <(cat <<'  END_PERL'
-    use strict; use warnings;
-    $| = 1;
+    use strict; use warnings; use warnings FATAL => 'all'; use 5.10.0;
+    use Data::Dumper;
+    STDOUT->autoflush(1);
+    STDERR->autoflush(1);
+    # ble.sh is eating STDERR at this point so to get feedback we do this:
+    $SIG{__WARN__} = sub {
+      print STDERR "in perlRegexServer bgproc: ".$_[0];
+    };
+    $SIG{__DIE__}  = sub {
+      print STDERR "in perlRegexServer bgproc: ".$_[0]; exit 1;
+    };
+    my $mlf = undef;   # My Log File (leave undef to disable logging)
+    #open($mlf, ">>/tmp/mlf") or die; $mlf->autoflush(1);
     while ( 1 ) {
-      my $rex = <>;
-      chomp($rex);
-      my $str = <>;
+      chomp(my $rex = <>);   # First line is regex
+      defined($rex) or exit;   # undef might mean end of pipe.  I think
+      defined($mlf) and print $mlf "from perl: \$rex: $rex\n";
+      chomp(my $lc = <>);    # Next line is number of lines in string to match
+      defined($lc) or exit; # undef might mean end of pipe.  I think
+      defined($mlf) and print $mlf "from perl: \$lc: $lc\n";
+      my $str = '';          # String to match
+      for ( my $ii = 0 ; $ii < $lc ; $ii++ ) {   # Get Lines
+        my $nsl = <>;   # New String Line
+        defined($nsl) or exit;   # undef might mean end of pipe.  I think
+        $str .= $nsl;
+      }
+      chomp($str);   # Remove trailing "\n" of last line
+      defined($mlf) and print $mlf "from perl: \$str: $str\n";
+      # Respond with blank line if the match fails, otherwise with a single
+      # line of the form:
+      #    epm eps epl g1m g1s g1l g2m g2s g2l ...
+      # where epm/eps/epl are Entire Pattern Matched (1)/Start/Length and
+      # g1m/g1s/g1l are (capture) Group 1 Matched (0 or 1)/Start/Lengh, etc.
+      # (where Start/Length may be 'undef').  Note that epm is always 1 since
+      # we return an empty line if the match fails.
       if ( $str =~ m/$rex/ ) {
-        # FIXME: Sadly this die argument doesn't show anywhere:
-        defined($1) or die 'group $1 unexpectedly undefined';
-        print length($1);
+        print
+          join(
+            ' ',
+            map {
+              defined($+[$_])
+              ? "1 $-[$_] ".($+[$_] - $-[$_])
+              : '0 undef undef'
+            }
+            (0 .. $#+) );
       }
       print "\n";
     }
@@ -33,7 +69,10 @@ function ble/contrib/config:github302/perlre-server {
   ) 2>/dev/tty
 }
 
-if ble/util/bgproc#open perlre_server ble/contrib/config:github302/perlre-server; then
+# restart so user can easily try again if they send a bad regex.
+# kill-timeout=0 because on some terminals ble.sh will end up exiting slowly
+# if we wait before sending SIGTERM
+if ble/util/bgproc#open perlre_server ble/contrib/config:github302/perlre-server restart:kill-timeout=0; then
   # The main shell can send a request to fd ${perlre_server_bgproc[1]} and can
   # read from fd ${perlre_server_bgproc[0]}.
   ble/util/print "ble/contrib/config:github30: perlre-server (${perlre_server_bgproc[4]}) has started." >&2
@@ -43,33 +82,43 @@ else
 fi
 
 ## @fn ble/contrib/config:github302/perlre-match rex str
-##   Matches the regex REX against the string STR and returns the length of the
-##   string captured by the first matching group ($1).
+##
+##   Matches the regex REX against the string STR
 ##
 ##   @param[in] rex
-##     The regex to match in "perlre" syntax.
+##     The regex to match in "perlre" syntax.   Must be exactly one line long.
 ##   @param[in] str
-##     The string to be matched by REX.
+##     The string to be matched by REX.  May be multiple lines.
 ##   @var[out] ret
-##     The resulting length of the string matched by the first capture group is
-##     stored in this variable.  When REX does not match STR, an empty value is
-##     stored in this variable.
+##     A blank line if the match failed, otherwise a single line of the form:
+##       epm eps eml g1m g1s g1l g2m g2s g2l ...
+##     where epm/eps/epl are Entire Pattern Matched (1)/Start/Length and
+##     g1m/g1s/g1l are (capture) Group 1 Matched (0 or 1)/Start/Lengh, etc.
+##     (where Start/Length may be 'undef').  Note that epm is always 1 here
+##     since we return an empty line if the match fails.
 ##   @exit 0 if REX successfully matches STR, or otherwise 1.
 ##
 function ble/contrib/config:github302/perlre-match {
-  local IFS=$' \t\n'
 
-  # Only takes the first lines of both because newlines in requests confuse the
-  # server.
-  local rex=${1%%$'\n'*} str=${2%%$'\n'*}
+  # FIXXME: could use #post instead of #use followed by echo but I'm too lazy
+  # and scared to figure how to get all the lines through correctly right now
 
-  # We send the requests to fd ${perlre_server_bgproc[1]}.
-  ble/util/print-lines "$rex" "$str" >&"${perlre_server_bgproc[1]}"
+  ble/util/bgproc#use perlre_server
+
+  {                               \
+    echo "$1"                     \
+    &&                            \
+    local tmp="${2//[!$'\n']/}"   \
+    &&                            \
+    echo $((${#tmp} + 1))         \
+    &&                            \
+    echo "$2";                    \
+  }                               \
+  >&"${perlre_server_bgproc[1]}";
 
   # We can read the resposnes from fd ${perlre_server_bgproc[0]}.  We set a
   # timeout to `read' so that it doesn't lock forever in case that the expected
-  # output is not obtained by accident (e.g., for the reason that REX did not
-  # contain any capturing group accessible through $1).
+  # output is not obtained by accident.
   ble/bash/read-timeout 1 -r -u "${perlre_server_bgproc[0]}" ret
 
   [[ $ret ]]


### PR DESCRIPTION
This is a slight elaboration on the earlier perlre-server st all group info is returned.  This is the version my clone of
chaoren/vim-wordmotion uses (I'm hoping to submit that to contrib somewhere soon).

This is some output when restart happens (not really a problem and maybe desirable):

```
$ echo "$foo"                                              2058
foo
bar
----------------------------------------------------------------
$ type mtest                                               2059
mtest is a function
mtest ()
{
    local ret;
    ble/contrib/config:github302/perlre-match "$1" "$2";
    echo $ret
}
----------------------------------------------------------------
$ mtest "b(ar" "$foo"                                      2060
in perlRegexServer bgproc: Unmatched ( in regex; marked by <-- HERE in m/b( <-- HERE ar/ at /dev/fd/63 line 36, <> line 8.

----------------------------------------------------------------
$ mtest "b(ar)" "$foo"                                     2061
bash: kill: (99220) - No such process
1 4 3 1 5 2
----------------------------------------------------------------
```