### PR TITLE
fix(config): bleopt/declare in github48{1,3}

### DIFF
--- a/config/github481-elapsed-mark-without-command.bash
+++ b/config/github481-elapsed-mark-without-command.bash
@@ -1,6 +1,6 @@
 # blesh/contrib/config/github481-elapsed-mark-without-command.bash (C) 2024, Koichi Murase <myoga.murase@gmail.com>
 
-bleopt/declare -v github481_elapsed_mark=$'\e[94m[ble: elapsed %s (CPU %s%%)]\e[m'
+bleopt/declare -v github481_elapsed_mark $'\e[94m[ble: elapsed %s (CPU %s%%)]\e[m'
 
 function ble/contrib/config:github481/elapsed-mark-without-command.hook {
   ble/exec/time#mark-enabled || return 0

--- a/config/github483-elapsed-mark-on-error.bash
+++ b/config/github483-elapsed-mark-on-error.bash
@@ -1,6 +1,6 @@
 # blesh/contrib/config/github483-elapsed-mark-on-error.bash (C) 2024, Koichi Murase <myoga.murase@gmail.com>
 
-bleopt/declare -v github483_elapsed_mark=$'\e[94m[ble: elapsed %s (CPU %s%%)]\e[m'
+bleopt/declare -v github483_elapsed_mark $'\e[94m[ble: elapsed %s (CPU %s%%)]\e[m'
 
 function ble/contrib/config:github483/elapsed-mark-on-error.hook {
   ((_ble_edit_exec_lastexit)) || ble/exec/time#mark-enabled || return 0


### PR DESCRIPTION
When I tried using https://github.com/akinomyoga/ble.sh/issues/481#issuecomment-2304374958, I got the following error:

```sh
+++++ bleopt/declare -v 'github481_elapsed_mark=[ble: elapsed %s (CPU %s%%)]'
+++++ local type=-v 'name=bleopt_github481_elapsed_mark=[ble: elapsed %s (CPU %s%%)]' default_value=
+++++ case $type in
+++++ builtin eval -- '_ble_opt_def_github481_elapsed_mark=[ble: elapsed %s (CPU %s%%)]=$3'
-bash: eval: line 2045: syntax error near unexpected token `('
-bash: eval: line 2045: `_ble_opt_def_github481_elapsed_mark=[ble: elapsed %s (CPU %s%%)]=$3'
+++++ builtin eval -- ': "${bleopt_github481_elapsed_mark=[ble: elapsed %s (CPU %s%%)]=$default_value}"'
++++++ : '[ble: elapsed %s (CPU %s%%)]='
+++++ return 0
+++++ set +x
```

I applied a fix to both the github481 and github483 config scripts.