### PR TITLE
scheme: add color scheme "tokyo_night"

### DIFF
--- a/scheme/tokyo_night.bash
+++ b/scheme/tokyo_night.bash
@@ -1,0 +1,96 @@
+# ble.sh Color Scheme inspired by Tokyo Night theme for NeoVim created by folke.
+# https://github.com/folke/tokyonight.nvim
+
+ble-import contrib/scheme/default
+
+function ble/contrib/scheme:tokyo_night/initialize {
+  ble/contrib/scheme:default/initialize
+
+  # highlighting related to editing
+  ble-face -s region                    "bg=#1a1b26,fg=#c0caf5"          # bg, fg
+  ble-face -s region_target             "bg=#bb9af7,fg=#16161e"          # magenta, bg_dark
+  ble-face -s region_match              "bg=#292e42,fg=#c0caf5"          # bg_highlight, fg
+  ble-face -s region_insert             "fg=#7aa2f7,bg=#292e42"          # blue, bg_highlight
+  ble-face -s disabled                  "fg=#565f89"                     # comment
+  ble-face -s overwrite_mode            "fg=#16161e,bg=#7dcfff"          # bg_dark, cyan
+  ble-face -s vbell                     reverse
+  ble-face -s vbell_erase               "bg=#292e42"                     # bg_highlight
+  ble-face -s vbell_flash               "fg=#9ece6a,reverse"             # green, reverse
+  ble-face -s prompt_status_line        "fg=#c0caf5,bg=#737aa2"          # fg, dark5
+
+  # syntax highlighting
+  ble-face -s syntax_default            none
+  ble-face -s syntax_command            "fg=#bb9af7"                     # magenta
+  ble-face -s syntax_quoted             "fg=#9ece6a"                     # green
+  ble-face -s syntax_quotation          "fg=#9ece6a,bold"                # green bold
+  ble-face -s syntax_escape             "fg=#bb9af7"                     # magenta
+  ble-face -s syntax_expr               "fg=#0db9d7"                     # blue2
+  ble-face -s syntax_error              "bg=#f7768e,fg=#c0caf5"          # red bg, fg
+  ble-face -s syntax_varname            "fg=#ff9e64"                     # orange
+  ble-face -s syntax_delimiter          bold
+  ble-face -s syntax_param_expansion    "fg=#6183bb"                     # git.change (blueish)
+  ble-face -s syntax_history_expansion  "bg=#89ddff,fg=#c0caf5"          # blue5 bg, fg
+  ble-face -s syntax_function_name      "fg=#394b70,bold"                # blue7 bold
+  ble-face -s syntax_comment            "fg=#565f89"                     # comment
+  ble-face -s syntax_glob               "fg=#ff9e64,bold"                # orange bold
+  ble-face -s syntax_brace              "fg=#545c7e,bold"                # dark3 bold
+  ble-face -s syntax_tilde              "fg=#9d7cd8,bold"                # purple bold
+  ble-face -s syntax_document           "fg=#737aa2"                     # dark5
+  ble-face -s syntax_document_begin     "fg=#737aa2,bold"                # dark5 bold
+
+  # command highlighting
+  ble-face -s command_builtin_dot       "fg=#f7768e,bold"                # red bold
+  ble-face -s command_builtin           "fg=#f7768e"                    # red
+  ble-face -s command_alias             "fg=#1abc9c"                    # teal
+  ble-face -s command_function          "fg=#394b70"                    # blue7
+  ble-face -s command_file              "fg=#9ece6a"                    # green
+  ble-face -s command_keyword           "fg=#7aa2f7"                    # blue
+  ble-face -s command_jobs              "fg=#f7768e"                    # red
+  ble-face -s command_directory         "fg=#0db9d7,underline"          # blue2 underline
+  ble-face -s command_suffix            "fg=#c0caf5,bg=#16161e"         # fg, bg_dark
+  ble-face -s command_suffix_new        "fg=#c0caf5,bg=#f7768e"         # fg, red bg
+
+  # filename highlighting
+  ble-face -s filename_directory        "underline,fg=#0db9d7"          # underline, blue2
+  ble-face -s filename_directory_sticky "underline,fg=#c0caf5,bg=#292e42" # underline, fg, bg_highlight
+  ble-face -s filename_link             "underline,fg=#1abc9c"          # underline, teal
+  ble-face -s filename_orphan           "underline,fg=#16161e,bg=#e0af68" # underline, bg_dark fg, yellow bg
+  ble-face -s filename_executable       "underline,fg=#9ece6a"          # underline, green
+  ble-face -s filename_setuid           "underline,fg=#16161e,bg=#e0af68" # underline, bg_dark fg, yellow bg
+  ble-face -s filename_setgid           "underline,fg=#16161e,bg=#bb9af7" # underline, bg_dark fg, magenta bg
+  ble-face -s filename_other            underline
+  ble-face -s filename_socket           "underline,fg=#7dcfff,bg=#16161e" # underline, cyan fg, bg_dark bg
+  ble-face -s filename_pipe             "underline,fg=#9ece6a,bg=#16161e" # underline, green fg, bg_dark bg
+  ble-face -s filename_character        "underline,fg=#c0caf5,bg=#16161e" # underline, fg, bg_dark bg
+  ble-face -s filename_block            "underline,fg=#e0af68,bg=#16161e" # underline, yellow fg, bg_dark bg
+  ble-face -s filename_warning          "underline,fg=#f7768e"          # underline, red fg
+  ble-face -s filename_url              "underline,fg=#7aa2f7"          # underline, blue fg
+  ble-face -s filename_ls_colors        underline
+
+  # varname highlighting
+  ble-face -s varname_array             "fg=#ff9e64,bold"               # orange bold
+  ble-face -s varname_empty             "fg=#2ac3de"                   # blue1
+  ble-face -s varname_export            "fg=#bb9af7,bold"              # magenta bold
+  ble-face -s varname_expr              "fg=#394b70,bold"              # blue7 bold
+  ble-face -s varname_hash              "fg=#41a6b5,bold"              # green2 bold
+  ble-face -s varname_new               "fg=#73daca"                   # green1
+  ble-face -s varname_number            "fg=#7aa2f7"                   # blue
+  ble-face -s varname_readonly          "fg=#bb9af7"                   # magenta
+  ble-face -s varname_transform         "fg=#0db9d7,bold"              # blue2 bold
+  ble-face -s varname_unset             "fg=#565f89"                   # comment
+
+  # argument highlighting
+  ble-face -s argument_option           "fg=#1abc9c"                   # teal
+  ble-face -s argument_error            "fg=#16161e,bg=#e0af68"        # bg_dark fg, yellow bg
+
+  # highlighting for completions
+  ble-face -s auto_complete             "fg=#238, bg=#254"             # approximate fg=238, bg=254 from default (use blue6 and bg_highlight)
+  ble-face -s menu_complete_match       bold
+  ble-face -s menu_complete_selected    reverse
+  ble-face -s menu_desc_default         none
+  ble-face -s menu_desc_type            ref:syntax_delimiter
+  ble-face -s menu_desc_quote           ref:syntax_quoted
+  ble-face -s menu_filter_fixed         bold
+  ble-face -s menu_filter_input         "fg=#16161e,bg=#e5e5e5"       # fg=16,bg=229 approx (bg light gray)
+
+}

--- a/scheme/tokyo_night.bash
+++ b/scheme/tokyo_night.bash
@@ -6,91 +6,107 @@ ble-import contrib/scheme/default
 function ble/contrib/scheme:tokyo_night/initialize {
   ble/contrib/scheme:default/initialize
 
+  ble/color/alias/set basic0  '#16161e' # bg_dark
+  ble/color/alias/set basic1  '#f7768e' # red
+  ble/color/alias/set basic2  '#9ece6a' # green
+  ble/color/alias/set basic3  '#e0af68' # yellow 
+  ble/color/alias/set basic4  '#7aa2f7' # blue
+  ble/color/alias/set basic5  '#bb9af7' # magenta
+  ble/color/alias/set basic6  '#7dcfff' # cyan
+  ble/color/alias/set basic7  '#7dcfff' # bg
+  ble/color/alias/set basic15 '#c0caf5' # fg
+  ble/color/alias/set custom1 '#292e42' # bg_highlight
+  ble/color/alias/set custom2 '#0db9d7' # blue2
+  ble/color/alias/set custom3 '#394b70' # blue7
+  ble/color/alias/set custom4 '#565f89' # comment
+  ble/color/alias/set custom5 '#737aa2' # dark5
+  ble/color/alias/set custom6 '#ff9e64' # orange
+  ble/color/alias/set custom7 '#1abc9c' # teal
+
   # highlighting related to editing
-  ble-face -s region                    "bg=#1a1b26,fg=#c0caf5"          # bg, fg
-  ble-face -s region_target             "bg=#bb9af7,fg=#16161e"          # magenta, bg_dark
-  ble-face -s region_match              "bg=#292e42,fg=#c0caf5"          # bg_highlight, fg
-  ble-face -s region_insert             "fg=#7aa2f7,bg=#292e42"          # blue, bg_highlight
-  ble-face -s disabled                  "fg=#565f89"                     # comment
-  ble-face -s overwrite_mode            "fg=#16161e,bg=#7dcfff"          # bg_dark, cyan
+  ble-face -s region                    "bg=%basic7,fg=%basic15"
+  ble-face -s region_target             "bg=%basic5,fg=%basic0"
+  ble-face -s region_match              "bg=%custom1,fg=%basic15"
+  ble-face -s region_insert             "fg=%basic4,bg=%custom1"
+  ble-face -s disabled                  "fg=%custom4"
+  ble-face -s overwrite_mode            "fg=%basic0,bg=%basic6"
   ble-face -s vbell                     reverse
-  ble-face -s vbell_erase               "bg=#292e42"                     # bg_highlight
-  ble-face -s vbell_flash               "fg=#9ece6a,reverse"             # green, reverse
-  ble-face -s prompt_status_line        "fg=#c0caf5,bg=#737aa2"          # fg, dark5
+  ble-face -s vbell_erase               "bg=%custom1"
+  ble-face -s vbell_flash               "fg=%basic2,reverse"
+  ble-face -s prompt_status_line        "fg=%basic15,bg=%custom5"
 
   # syntax highlighting
   ble-face -s syntax_default            none
-  ble-face -s syntax_command            "fg=#bb9af7"                     # magenta
-  ble-face -s syntax_quoted             "fg=#9ece6a"                     # green
-  ble-face -s syntax_quotation          "fg=#9ece6a,bold"                # green bold
-  ble-face -s syntax_escape             "fg=#bb9af7"                     # magenta
-  ble-face -s syntax_expr               "fg=#0db9d7"                     # blue2
-  ble-face -s syntax_error              "bg=#f7768e,fg=#c0caf5"          # red bg, fg
-  ble-face -s syntax_varname            "fg=#ff9e64"                     # orange
+  ble-face -s syntax_command            "fg=%basic5"
+  ble-face -s syntax_quoted             "fg=%basic2"
+  ble-face -s syntax_quotation          "fg=%basic2,bold"
+  ble-face -s syntax_escape             "fg=%basic5"
+  ble-face -s syntax_expr               "fg=%custom2"
+  ble-face -s syntax_error              "bg=%basic1,fg=%basic15"
+  ble-face -s syntax_varname            "fg=%custom6"
   ble-face -s syntax_delimiter          bold
-  ble-face -s syntax_param_expansion    "fg=#6183bb"                     # git.change (blueish)
-  ble-face -s syntax_history_expansion  "bg=#89ddff,fg=#c0caf5"          # blue5 bg, fg
-  ble-face -s syntax_function_name      "fg=#394b70,bold"                # blue7 bold
-  ble-face -s syntax_comment            "fg=#565f89"                     # comment
-  ble-face -s syntax_glob               "fg=#ff9e64,bold"                # orange bold
-  ble-face -s syntax_brace              "fg=#545c7e,bold"                # dark3 bold
-  ble-face -s syntax_tilde              "fg=#9d7cd8,bold"                # purple bold
-  ble-face -s syntax_document           "fg=#737aa2"                     # dark5
-  ble-face -s syntax_document_begin     "fg=#737aa2,bold"                # dark5 bold
+  ble-face -s syntax_param_expansion    "fg=#6183bb"             # git.change (blueish)
+  ble-face -s syntax_history_expansion  "bg=#89ddff,fg=%basic15" # bg=blue5
+  ble-face -s syntax_function_name      "fg=%custom3,bold"
+  ble-face -s syntax_comment            "fg=%custom4"
+  ble-face -s syntax_glob               "fg=%custom6,bold"
+  ble-face -s syntax_brace              "fg=#545c7e,bold"        # fg=dark3
+  ble-face -s syntax_tilde              "fg=#9d7cd8,bold"        # fg=purple
+  ble-face -s syntax_document           "fg=%custom5"
+  ble-face -s syntax_document_begin     "fg=%custom5,bold"
 
   # command highlighting
-  ble-face -s command_builtin_dot       "fg=#f7768e,bold"                # red bold
-  ble-face -s command_builtin           "fg=#f7768e"                    # red
-  ble-face -s command_alias             "fg=#1abc9c"                    # teal
-  ble-face -s command_function          "fg=#394b70"                    # blue7
-  ble-face -s command_file              "fg=#9ece6a"                    # green
-  ble-face -s command_keyword           "fg=#7aa2f7"                    # blue
-  ble-face -s command_jobs              "fg=#f7768e"                    # red
-  ble-face -s command_directory         "fg=#0db9d7,underline"          # blue2 underline
-  ble-face -s command_suffix            "fg=#c0caf5,bg=#16161e"         # fg, bg_dark
-  ble-face -s command_suffix_new        "fg=#c0caf5,bg=#f7768e"         # fg, red bg
+  ble-face -s command_builtin_dot       "fg=%basic1,bold"
+  ble-face -s command_builtin           "fg=%basic1"
+  ble-face -s command_alias             "fg=%custom7"
+  ble-face -s command_function          "fg=%custom3"
+  ble-face -s command_file              "fg=%basic2"
+  ble-face -s command_keyword           "fg=%basic4"
+  ble-face -s command_jobs              "fg=%basic1"
+  ble-face -s command_directory         "fg=%custom2,underline"
+  ble-face -s command_suffix            "fg=%basic15,bg=%basic0"
+  ble-face -s command_suffix_new        "fg=%basic15,bg=%basic1"
 
   # filename highlighting
-  ble-face -s filename_directory        "underline,fg=#0db9d7"          # underline, blue2
-  ble-face -s filename_directory_sticky "underline,fg=#c0caf5,bg=#292e42" # underline, fg, bg_highlight
-  ble-face -s filename_link             "underline,fg=#1abc9c"          # underline, teal
-  ble-face -s filename_orphan           "underline,fg=#16161e,bg=#e0af68" # underline, bg_dark fg, yellow bg
-  ble-face -s filename_executable       "underline,fg=#9ece6a"          # underline, green
-  ble-face -s filename_setuid           "underline,fg=#16161e,bg=#e0af68" # underline, bg_dark fg, yellow bg
-  ble-face -s filename_setgid           "underline,fg=#16161e,bg=#bb9af7" # underline, bg_dark fg, magenta bg
+  ble-face -s filename_directory        "underline,fg=%custom2"
+  ble-face -s filename_directory_sticky "underline,fg=%basic15,bg=%custom1"
+  ble-face -s filename_link             "underline,fg=%custom7"
+  ble-face -s filename_orphan           "underline,fg=%basic0,bg=%basic3"
+  ble-face -s filename_executable       "underline,fg=%basic2"
+  ble-face -s filename_setuid           "underline,fg=%basic0,bg=%basic3"
+  ble-face -s filename_setgid           "underline,fg=%basic0,bg=%basic5"
   ble-face -s filename_other            underline
-  ble-face -s filename_socket           "underline,fg=#7dcfff,bg=#16161e" # underline, cyan fg, bg_dark bg
-  ble-face -s filename_pipe             "underline,fg=#9ece6a,bg=#16161e" # underline, green fg, bg_dark bg
-  ble-face -s filename_character        "underline,fg=#c0caf5,bg=#16161e" # underline, fg, bg_dark bg
-  ble-face -s filename_block            "underline,fg=#e0af68,bg=#16161e" # underline, yellow fg, bg_dark bg
-  ble-face -s filename_warning          "underline,fg=#f7768e"          # underline, red fg
-  ble-face -s filename_url              "underline,fg=#7aa2f7"          # underline, blue fg
+  ble-face -s filename_socket           "underline,fg=%basic6,bg=%basic0"
+  ble-face -s filename_pipe             "underline,fg=%basic2,bg=%basic0"
+  ble-face -s filename_character        "underline,fg=%basic15,bg=%basic0"
+  ble-face -s filename_block            "underline,fg=%basic3,bg=%basic0"
+  ble-face -s filename_warning          "underline,fg=%basic1"
+  ble-face -s filename_url              "underline,fg=%basic4"
   ble-face -s filename_ls_colors        underline
 
   # varname highlighting
-  ble-face -s varname_array             "fg=#ff9e64,bold"               # orange bold
-  ble-face -s varname_empty             "fg=#2ac3de"                   # blue1
-  ble-face -s varname_export            "fg=#bb9af7,bold"              # magenta bold
-  ble-face -s varname_expr              "fg=#394b70,bold"              # blue7 bold
-  ble-face -s varname_hash              "fg=#41a6b5,bold"              # green2 bold
-  ble-face -s varname_new               "fg=#73daca"                   # green1
-  ble-face -s varname_number            "fg=#7aa2f7"                   # blue
-  ble-face -s varname_readonly          "fg=#bb9af7"                   # magenta
-  ble-face -s varname_transform         "fg=#0db9d7,bold"              # blue2 bold
-  ble-face -s varname_unset             "fg=#565f89"                   # comment
+  ble-face -s varname_array             "fg=%custom6,bold"
+  ble-face -s varname_empty             "fg=#2ac3de"                  # fg=blue1
+  ble-face -s varname_export            "fg=%basic5,bold"
+  ble-face -s varname_expr              "fg=%custom3,bold"
+  ble-face -s varname_hash              "fg=#41a6b5,bold"             # fg=green2
+  ble-face -s varname_new               "fg=#73daca"                  # fg=green1
+  ble-face -s varname_number            "fg=%basic4"
+  ble-face -s varname_readonly          "fg=%basic5"
+  ble-face -s varname_transform         "fg=%custom2,bold"
+  ble-face -s varname_unset             "fg=%custom4"
 
   # argument highlighting
-  ble-face -s argument_option           "fg=#1abc9c"                   # teal
-  ble-face -s argument_error            "fg=#16161e,bg=#e0af68"        # bg_dark fg, yellow bg
+  ble-face -s argument_option           "fg=%custom7"
+  ble-face -s argument_error            "fg=%basic0,bg=%basic3"
 
   # highlighting for completions
-  ble-face -s auto_complete             "fg=#238, bg=#254"             # approximate fg=238, bg=254 from default (use blue6 and bg_highlight)
+  ble-face -s auto_complete             "fg=#238, bg=#254"            # approximate fg=238, bg=254 from default (use blue6 and bg_highlight)
   ble-face -s menu_complete_match       bold
   ble-face -s menu_complete_selected    reverse
   ble-face -s menu_desc_default         none
   ble-face -s menu_desc_type            ref:syntax_delimiter
   ble-face -s menu_desc_quote           ref:syntax_quoted
   ble-face -s menu_filter_fixed         bold
-  ble-face -s menu_filter_input         "fg=#16161e,bg=#e5e5e5"       # fg=16,bg=229 approx (bg light gray)
-
+  ble-face -s menu_filter_input         "fg=%basic0,bg=#e5e5e5"       # bg=light_gray (fg=16,bg=229 approx)
 }

--- a/scheme/tokyo_night.bash
+++ b/scheme/tokyo_night.bash
@@ -101,7 +101,7 @@ function ble/contrib/scheme:tokyo_night/initialize {
   ble-face -s argument_error            "fg=%basic0,bg=%basic3"
 
   # highlighting for completions
-  ble-face -s auto_complete             "fg=#238, bg=#254"            # approximate fg=238, bg=254 from default (use blue6 and bg_highlight)
+  ble-face -s auto_complete             "fg=#b4f9f8,bg=#292e42"       # approximate fg=238, bg=254 from default (use blue6 and bg_highlight)
   ble-face -s menu_complete_match       bold
   ble-face -s menu_complete_selected    reverse
   ble-face -s menu_desc_default         none

--- a/scheme/tokyonight.bash
+++ b/scheme/tokyonight.bash
@@ -3,7 +3,7 @@
 
 ble-import contrib/scheme/default
 
-function ble/contrib/scheme:tokyo_night/initialize {
+function ble/contrib/scheme:tokyonight/initialize {
   ble/contrib/scheme:default/initialize
 
   ble/color/alias/set basic0  '#16161e' # bg_dark

--- a/scheme/tokyonight.bash
+++ b/scheme/tokyonight.bash
@@ -6,107 +6,116 @@ ble-import contrib/scheme/default
 function ble/contrib/scheme:tokyonight/initialize {
   ble/contrib/scheme:default/initialize
 
-  ble/color/alias/set basic0  '#16161e' # bg_dark
-  ble/color/alias/set basic1  '#f7768e' # red
-  ble/color/alias/set basic2  '#9ece6a' # green
-  ble/color/alias/set basic3  '#e0af68' # yellow 
-  ble/color/alias/set basic4  '#7aa2f7' # blue
-  ble/color/alias/set basic5  '#bb9af7' # magenta
-  ble/color/alias/set basic6  '#7dcfff' # cyan
-  ble/color/alias/set basic7  '#7dcfff' # bg
-  ble/color/alias/set basic15 '#c0caf5' # fg
-  ble/color/alias/set custom1 '#292e42' # bg_highlight
-  ble/color/alias/set custom2 '#0db9d7' # blue2
-  ble/color/alias/set custom3 '#394b70' # blue7
-  ble/color/alias/set custom4 '#565f89' # comment
-  ble/color/alias/set custom5 '#737aa2' # dark5
-  ble/color/alias/set custom6 '#ff9e64' # orange
-  ble/color/alias/set custom7 '#1abc9c' # teal
+  ble/color/alias/set basic0   '#16161e' # bg_dark
+  ble/color/alias/set basic1   '#f7768e' # red
+  ble/color/alias/set basic2   '#9ece6a' # green
+  ble/color/alias/set basic3   '#e0af68' # yellow 
+  ble/color/alias/set basic4   '#7aa2f7' # blue
+  ble/color/alias/set basic5   '#9d7cd8' # purple
+  ble/color/alias/set basic6   '#1abc9c' # teal
+  ble/color/alias/set basic7   '#c0caf5' # fg
+  ble/color/alias/set basic8   '#7dcfff' # bg
+  ble/color/alias/set basic9   '#ff9e64' # orange
+  ble/color/alias/set basic13  '#bb9af7' # magenta
+  ble/color/alias/set basic14  '#7dcfff' # cyan
+  ble/color/alias/set basic15  '#e5e5e5' # light_gray                    
+  ble/color/alias/set custom1  '#292e42' # bg_highlight
+  ble/color/alias/set custom2  '#2ac3de' # blue1
+  ble/color/alias/set custom3  '#0db9d7' # blue2
+  ble/color/alias/set custom4  '#89ddff' # blue5
+  ble/color/alias/set custom5  '#b4f9f8' # blue6
+  ble/color/alias/set custom6  '#394b70' # blue7
+  ble/color/alias/set custom7  '#565f89' # comment
+  ble/color/alias/set custom8  '#545c7e' # dark3 
+  ble/color/alias/set custom9  '#737aa2' # dark5
+  ble/color/alias/set custom10 '#6183bb' # git.change (blueish)
+  ble/color/alias/set custom11 '#73daca' # green1
+  ble/color/alias/set custom12 '#41a6b5' # green2
 
   # highlighting related to editing
-  ble-face -s region                    "bg=%basic7,fg=%basic15"
-  ble-face -s region_target             "bg=%basic5,fg=%basic0"
-  ble-face -s region_match              "bg=%custom1,fg=%basic15"
+  ble-face -s region                    "bg=%basic8,fg=%basic7"
+  ble-face -s region_target             "bg=%basic13,fg=%basic0"
+  ble-face -s region_match              "bg=%custom1,fg=%basic7"
   ble-face -s region_insert             "fg=%basic4,bg=%custom1"
-  ble-face -s disabled                  "fg=%custom4"
-  ble-face -s overwrite_mode            "fg=%basic0,bg=%basic6"
+  ble-face -s disabled                  "fg=%custom7"
+  ble-face -s overwrite_mode            "fg=%basic0,bg=%basic14"
   ble-face -s vbell                     reverse
   ble-face -s vbell_erase               "bg=%custom1"
   ble-face -s vbell_flash               "fg=%basic2,reverse"
-  ble-face -s prompt_status_line        "fg=%basic15,bg=%custom5"
+  ble-face -s prompt_status_line        "fg=%basic7,bg=%custom9"
 
   # syntax highlighting
   ble-face -s syntax_default            none
-  ble-face -s syntax_command            "fg=%basic5"
+  ble-face -s syntax_command            "fg=%basic13"
   ble-face -s syntax_quoted             "fg=%basic2"
   ble-face -s syntax_quotation          "fg=%basic2,bold"
-  ble-face -s syntax_escape             "fg=%basic5"
-  ble-face -s syntax_expr               "fg=%custom2"
-  ble-face -s syntax_error              "bg=%basic1,fg=%basic15"
-  ble-face -s syntax_varname            "fg=%custom6"
+  ble-face -s syntax_escape             "fg=%basic13"
+  ble-face -s syntax_expr               "fg=%custom3"
+  ble-face -s syntax_error              "bg=%basic1,fg=%basic7"
+  ble-face -s syntax_varname            "fg=%basic9"
   ble-face -s syntax_delimiter          bold
-  ble-face -s syntax_param_expansion    "fg=#6183bb"             # git.change (blueish)
-  ble-face -s syntax_history_expansion  "bg=#89ddff,fg=%basic15" # bg=blue5
-  ble-face -s syntax_function_name      "fg=%custom3,bold"
-  ble-face -s syntax_comment            "fg=%custom4"
-  ble-face -s syntax_glob               "fg=%custom6,bold"
-  ble-face -s syntax_brace              "fg=#545c7e,bold"        # fg=dark3
-  ble-face -s syntax_tilde              "fg=#9d7cd8,bold"        # fg=purple
-  ble-face -s syntax_document           "fg=%custom5"
-  ble-face -s syntax_document_begin     "fg=%custom5,bold"
+  ble-face -s syntax_param_expansion    "fg=%custom10"    
+  ble-face -s syntax_history_expansion  "bg=%custom4,fg=%basic7"
+  ble-face -s syntax_function_name      "fg=%custom6,bold"
+  ble-face -s syntax_comment            "fg=%custom7"
+  ble-face -s syntax_glob               "fg=%basic9,bold"
+  ble-face -s syntax_brace              "fg=%custom8,bold"       
+  ble-face -s syntax_tilde              "fg=%basic5,bold"       
+  ble-face -s syntax_document           "fg=%custom9"
+  ble-face -s syntax_document_begin     "fg=%custom9,bold"
 
   # command highlighting
   ble-face -s command_builtin_dot       "fg=%basic1,bold"
   ble-face -s command_builtin           "fg=%basic1"
-  ble-face -s command_alias             "fg=%custom7"
-  ble-face -s command_function          "fg=%custom3"
+  ble-face -s command_alias             "fg=%basic6"
+  ble-face -s command_function          "fg=%custom6"
   ble-face -s command_file              "fg=%basic2"
   ble-face -s command_keyword           "fg=%basic4"
   ble-face -s command_jobs              "fg=%basic1"
-  ble-face -s command_directory         "fg=%custom2,underline"
-  ble-face -s command_suffix            "fg=%basic15,bg=%basic0"
-  ble-face -s command_suffix_new        "fg=%basic15,bg=%basic1"
+  ble-face -s command_directory         "fg=%custom3,underline"
+  ble-face -s command_suffix            "fg=%basic7,bg=%basic0"
+  ble-face -s command_suffix_new        "fg=%basic7,bg=%basic1"
 
   # filename highlighting
-  ble-face -s filename_directory        "underline,fg=%custom2"
-  ble-face -s filename_directory_sticky "underline,fg=%basic15,bg=%custom1"
-  ble-face -s filename_link             "underline,fg=%custom7"
+  ble-face -s filename_directory        "underline,fg=%custom3"
+  ble-face -s filename_directory_sticky "underline,fg=%basic7,bg=%custom1"
+  ble-face -s filename_link             "underline,fg=%basic6"
   ble-face -s filename_orphan           "underline,fg=%basic0,bg=%basic3"
   ble-face -s filename_executable       "underline,fg=%basic2"
   ble-face -s filename_setuid           "underline,fg=%basic0,bg=%basic3"
-  ble-face -s filename_setgid           "underline,fg=%basic0,bg=%basic5"
+  ble-face -s filename_setgid           "underline,fg=%basic0,bg=%basic13"
   ble-face -s filename_other            underline
-  ble-face -s filename_socket           "underline,fg=%basic6,bg=%basic0"
+  ble-face -s filename_socket           "underline,fg=%basic14,bg=%basic0"
   ble-face -s filename_pipe             "underline,fg=%basic2,bg=%basic0"
-  ble-face -s filename_character        "underline,fg=%basic15,bg=%basic0"
+  ble-face -s filename_character        "underline,fg=%basic7,bg=%basic0"
   ble-face -s filename_block            "underline,fg=%basic3,bg=%basic0"
   ble-face -s filename_warning          "underline,fg=%basic1"
   ble-face -s filename_url              "underline,fg=%basic4"
   ble-face -s filename_ls_colors        underline
 
   # varname highlighting
-  ble-face -s varname_array             "fg=%custom6,bold"
-  ble-face -s varname_empty             "fg=#2ac3de"                  # fg=blue1
-  ble-face -s varname_export            "fg=%basic5,bold"
-  ble-face -s varname_expr              "fg=%custom3,bold"
-  ble-face -s varname_hash              "fg=#41a6b5,bold"             # fg=green2
-  ble-face -s varname_new               "fg=#73daca"                  # fg=green1
+  ble-face -s varname_array             "fg=%basic9,bold"
+  ble-face -s varname_empty             "fg=%custom2"      
+  ble-face -s varname_export            "fg=%basic13,bold"
+  ble-face -s varname_expr              "fg=%custom6,bold"
+  ble-face -s varname_hash              "fg=%custom12,bold"
+  ble-face -s varname_new               "fg=%custom11"     
   ble-face -s varname_number            "fg=%basic4"
-  ble-face -s varname_readonly          "fg=%basic5"
-  ble-face -s varname_transform         "fg=%custom2,bold"
-  ble-face -s varname_unset             "fg=%custom4"
+  ble-face -s varname_readonly          "fg=%basic13"
+  ble-face -s varname_transform         "fg=%custom3,bold"
+  ble-face -s varname_unset             "fg=%custom7"
 
   # argument highlighting
-  ble-face -s argument_option           "fg=%custom7"
+  ble-face -s argument_option           "fg=%basic6"
   ble-face -s argument_error            "fg=%basic0,bg=%basic3"
 
   # highlighting for completions
-  ble-face -s auto_complete             "fg=#b4f9f8,bg=#292e42"       # approximate fg=238, bg=254 from default (use blue6 and bg_highlight)
+  ble-face -s auto_complete             "fg=%custom5,bg=%custom1" # approximate the default fg=238,bg=254
   ble-face -s menu_complete_match       bold
   ble-face -s menu_complete_selected    reverse
   ble-face -s menu_desc_default         none
   ble-face -s menu_desc_type            ref:syntax_delimiter
   ble-face -s menu_desc_quote           ref:syntax_quoted
   ble-face -s menu_filter_fixed         bold
-  ble-face -s menu_filter_input         "fg=%basic0,bg=#e5e5e5"       # bg=light_gray (fg=16,bg=229 approx)
+  ble-face -s menu_filter_input         "fg=%basic0,bg=%basic15"  # approximate the default fg=16,bg=229
 }

--- a/scheme/tokyonight.bash
+++ b/scheme/tokyonight.bash
@@ -33,89 +33,89 @@ function ble/contrib/scheme:tokyonight/initialize {
   ble/color/alias/set custom12 '#41a6b5' # green2
 
   # highlighting related to editing
-  ble-face -s region                    "bg=%basic8,fg=%basic7"
-  ble-face -s region_target             "bg=%basic13,fg=%basic0"
-  ble-face -s region_match              "bg=%custom1,fg=%basic7"
-  ble-face -s region_insert             "fg=%basic4,bg=%custom1"
-  ble-face -s disabled                  "fg=%custom7"
-  ble-face -s overwrite_mode            "fg=%basic0,bg=%basic14"
+  ble-face -s region                    bg=%basic8,fg=%basic7
+  ble-face -s region_target             bg=%basic13,fg=%basic0
+  ble-face -s region_match              bg=%custom1,fg=%basic7
+  ble-face -s region_insert             fg=%basic4,bg=%custom1
+  ble-face -s disabled                  fg=%custom7
+  ble-face -s overwrite_mode            fg=%basic0,bg=%basic14
   ble-face -s vbell                     reverse
-  ble-face -s vbell_erase               "bg=%custom1"
-  ble-face -s vbell_flash               "fg=%basic2,reverse"
-  ble-face -s prompt_status_line        "fg=%basic7,bg=%custom9"
+  ble-face -s vbell_erase               bg=%custom1
+  ble-face -s vbell_flash               fg=%basic2,reverse
+  ble-face -s prompt_status_line        fg=%basic7,bg=%custom9
 
   # syntax highlighting
   ble-face -s syntax_default            none
-  ble-face -s syntax_command            "fg=%basic13"
-  ble-face -s syntax_quoted             "fg=%basic2"
-  ble-face -s syntax_quotation          "fg=%basic2,bold"
-  ble-face -s syntax_escape             "fg=%basic13"
-  ble-face -s syntax_expr               "fg=%custom3"
-  ble-face -s syntax_error              "bg=%basic1,fg=%basic7"
-  ble-face -s syntax_varname            "fg=%basic9"
+  ble-face -s syntax_command            fg=%basic13
+  ble-face -s syntax_quoted             fg=%basic2
+  ble-face -s syntax_quotation          fg=%basic2,bold
+  ble-face -s syntax_escape             fg=%basic13
+  ble-face -s syntax_expr               fg=%custom3
+  ble-face -s syntax_error              bg=%basic1,fg=%basic7
+  ble-face -s syntax_varname            fg=%basic9
   ble-face -s syntax_delimiter          bold
-  ble-face -s syntax_param_expansion    "fg=%custom10"    
-  ble-face -s syntax_history_expansion  "bg=%custom4,fg=%basic7"
-  ble-face -s syntax_function_name      "fg=%custom6,bold"
-  ble-face -s syntax_comment            "fg=%custom7"
-  ble-face -s syntax_glob               "fg=%basic9,bold"
-  ble-face -s syntax_brace              "fg=%custom8,bold"       
-  ble-face -s syntax_tilde              "fg=%basic5,bold"       
-  ble-face -s syntax_document           "fg=%custom9"
-  ble-face -s syntax_document_begin     "fg=%custom9,bold"
+  ble-face -s syntax_param_expansion    fg=%custom10    
+  ble-face -s syntax_history_expansion  bg=%custom4,fg=%basic7
+  ble-face -s syntax_function_name      fg=%custom6,bold
+  ble-face -s syntax_comment            fg=%custom7
+  ble-face -s syntax_glob               fg=%basic9,bold
+  ble-face -s syntax_brace              fg=%custom8,bold       
+  ble-face -s syntax_tilde              fg=%basic5,bold       
+  ble-face -s syntax_document           fg=%custom9
+  ble-face -s syntax_document_begin     fg=%custom9,bold
 
   # command highlighting
-  ble-face -s command_builtin_dot       "fg=%basic1,bold"
-  ble-face -s command_builtin           "fg=%basic1"
-  ble-face -s command_alias             "fg=%basic6"
-  ble-face -s command_function          "fg=%custom6"
-  ble-face -s command_file              "fg=%basic2"
-  ble-face -s command_keyword           "fg=%basic4"
-  ble-face -s command_jobs              "fg=%basic1"
-  ble-face -s command_directory         "fg=%custom3,underline"
-  ble-face -s command_suffix            "fg=%basic7,bg=%basic0"
-  ble-face -s command_suffix_new        "fg=%basic7,bg=%basic1"
+  ble-face -s command_builtin_dot       fg=%basic1,bold
+  ble-face -s command_builtin           fg=%basic1
+  ble-face -s command_alias             fg=%basic6
+  ble-face -s command_function          fg=%custom6
+  ble-face -s command_file              fg=%basic2
+  ble-face -s command_keyword           fg=%basic4
+  ble-face -s command_jobs              fg=%basic1
+  ble-face -s command_directory         fg=%custom3,underline
+  ble-face -s command_suffix            fg=%basic7,bg=%basic0
+  ble-face -s command_suffix_new        fg=%basic7,bg=%basic1
 
   # filename highlighting
-  ble-face -s filename_directory        "underline,fg=%custom3"
-  ble-face -s filename_directory_sticky "underline,fg=%basic7,bg=%custom1"
-  ble-face -s filename_link             "underline,fg=%basic6"
-  ble-face -s filename_orphan           "underline,fg=%basic0,bg=%basic3"
-  ble-face -s filename_executable       "underline,fg=%basic2"
-  ble-face -s filename_setuid           "underline,fg=%basic0,bg=%basic3"
-  ble-face -s filename_setgid           "underline,fg=%basic0,bg=%basic13"
+  ble-face -s filename_directory        underline,fg=%custom3
+  ble-face -s filename_directory_sticky underline,fg=%basic7,bg=%custom1
+  ble-face -s filename_link             underline,fg=%basic6
+  ble-face -s filename_orphan           underline,fg=%basic0,bg=%basic3
+  ble-face -s filename_executable       underline,fg=%basic2
+  ble-face -s filename_setuid           underline,fg=%basic0,bg=%basic3
+  ble-face -s filename_setgid           underline,fg=%basic0,bg=%basic13
   ble-face -s filename_other            underline
-  ble-face -s filename_socket           "underline,fg=%basic14,bg=%basic0"
-  ble-face -s filename_pipe             "underline,fg=%basic2,bg=%basic0"
-  ble-face -s filename_character        "underline,fg=%basic7,bg=%basic0"
-  ble-face -s filename_block            "underline,fg=%basic3,bg=%basic0"
-  ble-face -s filename_warning          "underline,fg=%basic1"
-  ble-face -s filename_url              "underline,fg=%basic4"
+  ble-face -s filename_socket           underline,fg=%basic14,bg=%basic0
+  ble-face -s filename_pipe             underline,fg=%basic2,bg=%basic0
+  ble-face -s filename_character        underline,fg=%basic7,bg=%basic0
+  ble-face -s filename_block            underline,fg=%basic3,bg=%basic0
+  ble-face -s filename_warning          underline,fg=%basic1
+  ble-face -s filename_url              underline,fg=%basic4
   ble-face -s filename_ls_colors        underline
 
   # varname highlighting
-  ble-face -s varname_array             "fg=%basic9,bold"
-  ble-face -s varname_empty             "fg=%custom2"      
-  ble-face -s varname_export            "fg=%basic13,bold"
-  ble-face -s varname_expr              "fg=%custom6,bold"
-  ble-face -s varname_hash              "fg=%custom12,bold"
-  ble-face -s varname_new               "fg=%custom11"     
-  ble-face -s varname_number            "fg=%basic4"
-  ble-face -s varname_readonly          "fg=%basic13"
-  ble-face -s varname_transform         "fg=%custom3,bold"
-  ble-face -s varname_unset             "fg=%custom7"
+  ble-face -s varname_array             fg=%basic9,bold
+  ble-face -s varname_empty             fg=%custom2      
+  ble-face -s varname_export            fg=%basic13,bold
+  ble-face -s varname_expr              fg=%custom6,bold
+  ble-face -s varname_hash              fg=%custom12,bold
+  ble-face -s varname_new               fg=%custom11     
+  ble-face -s varname_number            fg=%basic4
+  ble-face -s varname_readonly          fg=%basic13
+  ble-face -s varname_transform         fg=%custom3,bold
+  ble-face -s varname_unset             fg=%custom7
 
   # argument highlighting
-  ble-face -s argument_option           "fg=%basic6"
-  ble-face -s argument_error            "fg=%basic0,bg=%basic3"
+  ble-face -s argument_option           fg=%basic6
+  ble-face -s argument_error            fg=%basic0,bg=%basic3
 
   # highlighting for completions
-  ble-face -s auto_complete             "fg=%custom5,bg=%custom1" # approximate the default fg=238,bg=254
+  ble-face -s auto_complete             fg=%custom5,bg=%custom1 # approximate the default fg=238,bg=254
   ble-face -s menu_complete_match       bold
   ble-face -s menu_complete_selected    reverse
   ble-face -s menu_desc_default         none
   ble-face -s menu_desc_type            ref:syntax_delimiter
   ble-face -s menu_desc_quote           ref:syntax_quoted
   ble-face -s menu_filter_fixed         bold
-  ble-face -s menu_filter_input         "fg=%basic0,bg=%basic15"  # approximate the default fg=16,bg=229
+  ble-face -s menu_filter_input         fg=%basic0,bg=%basic15  # approximate the default fg=16,bg=229
 }

--- a/scheme/tokyonight.bash
+++ b/scheme/tokyonight.bash
@@ -1,4 +1,4 @@
-# ble.sh Color Scheme inspired by Tokyo Night theme for NeoVim created by folke.
+# ble.sh Color Scheme inspired by Tokyo Night theme for NeoVim created by folke
 # https://github.com/folke/tokyonight.nvim
 
 ble-import contrib/scheme/default


### PR DESCRIPTION
Hi!

I've added a Tokyo Night color scheme for ble.sh, following the structure of the existing catppuccin_mocha scheme. This is my first contribution to GitHub, so please let me know if I need to adjust anything!

Original Tokyo Night NeoVim Theme (by folke): https://github.com/folke/tokyonight.nvim