### PR TITLE
integration/fzf-menu: add `_ble_contrib_fzf_menu_auto_complete` and `fzf-menu-complete` widget

### DIFF
--- a/config/alias-tips.bash
+++ b/config/alias-tips.bash
@@ -30,7 +30,7 @@ function ble/contrib/config:alias-tips/preexec.hook {
     # Only consider an alias that shortens a command line
     ((${#name} < ${#value})) || continue
 
-    # Only consider an alias value matching to the current command line
+    # Only consider an alias value matching the current command line
     ble/string#escape-for-extended-regex "$value"; local rex_value=$ret
     ble/string#match "$command" "^[$_ble_term_IFS]*$rex_value($|[$_ble_term_IFS=;|&()<>])" || continue
 

--- a/integration/fzf-menu.bash
+++ b/integration/fzf-menu.bash
@@ -2,6 +2,8 @@
 #
 # https://github.com/akinomyoga/ble.sh/issues/479
 
+bleopt/declare -v integration_fzf_menu_enabled 1
+
 _ble_contrib_fzf_menu_filter=
 function ble/contrib/integration:fzf-menu/initialize {
   builtin unset -f "$FUNCNAME"
@@ -75,6 +77,11 @@ function ble/contrib/integration:fzf-menu/.get-common-prefix {
 }
 
 function ble/contrib/integration:fzf-menu/.select-and-insert {
+  if [[ ! $bleopt_integration_fzf_menu_enabled ]]; then
+    ble/function#push/call-top "$@"
+    return "$?"
+  fi
+
   if ((cand_count>1)); then
     local common_prefix=
     ble/contrib/integration:fzf-menu/.get-common-prefix "${cand_cand[@]}"
@@ -129,9 +136,17 @@ function ble/contrib/integration:fzf-menu/.select-and-insert {
   return 148
 }
 
+# Runs the normal completion but shows fzf instead of ble.sh's built-in menu
+# when there are multiple candidates.
+function ble/widget/fzf-menu-complete {
+  local bleopt_integration_fzf_menu_enabled=1
+  ble/widget/complete
+}
+
 ble-import -C 'ble/function#push ble/complete/menu/show "ble/contrib/integration:fzf-menu/.select-and-insert"' core-complete
 
 # function ble/contrib/integration:fzf-menu/complete.after {
+#   [[ $bleopt_integration_fzf_menu_enabled ]] || return 0
 #   [[ $_ble_complete_menu_active ]] || return 0
 #   local COMP1 COMP2 COMPS COMPV
 #   local comp_type comps_flags comps_fixed

--- a/integration/fzf.md
+++ b/integration/fzf.md
@@ -199,11 +199,26 @@ To customize the selector, users can override the shell function
 candidates as arguments.  Each argument has the format `<index>^\<cand>^\-
 <desc>`, where `<index>`, `<cand>`, and `<desc>` are the index, the completion
 candidate, and its description, respectively, which are separated by the FS
-control character (U+001C) represented by `^\`.
+control character (U+001C, represented by `^\` in the above format).
 
-The default selector implementation uses fzf to show and let the user select a
-candidate.  This implementation uses util-linux's `column`, if found in the
-system, to format the candidate list shown in `fzf`.  Please install
-util-linux's column if you want to align the positions of the descriptions in
+The default selector implementation uses fzf to show the list and let the user
+select a candidate.  This implementation uses util-linux's `column`, if found
+in the system, to format the candidate list shown in `fzf`.  Please install
+util-linux's `column` if you want to align the positions of the descriptions in
 fzf.  For example, in macOS, util-linux can be installed using Homebrew with
 `brew install util-linux`.
+
+By default, importing this module replaces `ble.sh`'s built-in completion menu
+with fzf for all TAB completions.  To disable overriding the default behavior
+of the completion menu, set `bleopt integration_fzf_menu_enabled` to empty.
+The module also provides a widget `fzf-menu-complete` to manually call the
+completion with `fzf-menu` on demand:
+
+```bash
+# blerc
+
+ble-import -d integration/fzf-menu -C '
+  bleopt integration_fzf_menu_enabled=
+  ble-bind -m emacs -f S-TAB fzf-menu-complete
+'
+```


### PR DESCRIPTION
Add `_ble_contrib_fzf_menu_auto_complete` to control whether importing the
module automatically replaces ble.sh's built-in completion menu with fzf.

Add widget `fzf-menu-complete` that temporarily enables the fzf menu for
a single completion.  See the doc.

This allows user to default to ble.sh's default completion menu, but invoke fzf's menu
when desired.