### PR TITLE
contrib: fix apt policy completion spurious stderr from dumpavail

### DIFF
--- a/integration/bash-completion.bash
+++ b/integration/bash-completion.bash
@@ -297,46 +297,16 @@ function ble/contrib/integration:bash-completion/_do_dnf5_completion.advice {
   fi
 }
 
-## @fn ble/contrib/integration:bash-completion/apt/patch-function
-##   Fix broken "apt policy" (and related) completion in bash-completion.
-##
-##   bash-completion's _apt uses adjacent command substitutions and runs
-##   "apt-cache dumpavail" without stderr redirection.  "apt-cache dumpavail"
-##   emits "E: read, still have 1 to read but none left" to stderr when its
-##   stdout is captured by command substitution.  ble.sh auto-complete invokes
-##   completion on every key input, so the error appears after each keystroke.
-##
-##   https://github.com/akinomyoga/ble.sh/issues/545
-function ble/contrib/integration:bash-completion/apt/patch-function {
-  ble/is-function _apt || return 0
-
-  local lambda=ble/contrib/integration:bash-completion/apt/patch-function:orig
-  ble/is-function "$lambda" && return 0
-
-  local def
-  ble/util/assign def 'declare -f _apt' || return 0
-
-  local old='COMPREPLY=($(apt-cache --no-generate pkgnames "$cur" 2> /dev/null) $(apt-cache dumpavail | command grep "^Source: $cur" | sort -u | cut -f2 -d" "));'
-  local new='COMPREPLY=($({ apt-cache --no-generate pkgnames "$cur" 2> /dev/null; apt-cache dumpavail 2> /dev/null | command grep "^Source: $cur" | sort -u | cut -f2 -d" "; }));'
-  if [[ $def == *"$old"* ]]; then
-    def=${def//"$old"/"$new"}
-  elif [[ $def == *'apt-cache dumpavail |'* && $def != *'apt-cache dumpavail 2>'* ]]; then
-    def=${def//'apt-cache dumpavail |'/'apt-cache dumpavail 2> /dev/null |'}
-  else
-    return 0
-  fi
-
-  ble/function#.copy-primitive _apt "$lambda"
-  builtin eval "$def"
-}
-
 function ble/contrib/integration:bash-completion/adjust {
   ble/is-function _comp_initialize || ble/is-function _quote_readline_by_ref || return 0
 
   ble/contrib/integration:bash-completion/loader/adjust
 
+  # apt's _apt completion: apt-cache dumpavail stderr when captured by $()
+  # https://github.com/akinomyoga/ble.sh/issues/545
+  # upstream: https://salsa.debian.org/apt-team/apt/-/blob/master/completions/bash/apt
   [[ $comp_func == _apt ]] &&
-    ble/contrib/integration:bash-completion/apt/patch-function
+    ble/function#suppress-stderr _apt 2>/dev/null
 
   _ble_contrib_integration_bash_completion_cmd_conditional_sync=(_comp_cmd_make _make _do_dnf5_completion)
 

--- a/integration/bash-completion.bash
+++ b/integration/bash-completion.bash
@@ -297,10 +297,46 @@ function ble/contrib/integration:bash-completion/_do_dnf5_completion.advice {
   fi
 }
 
+## @fn ble/contrib/integration:bash-completion/apt/patch-function
+##   Fix broken "apt policy" (and related) completion in bash-completion.
+##
+##   bash-completion's _apt uses adjacent command substitutions and runs
+##   "apt-cache dumpavail" without stderr redirection.  "apt-cache dumpavail"
+##   emits "E: read, still have 1 to read but none left" to stderr when its
+##   stdout is captured by command substitution.  ble.sh auto-complete invokes
+##   completion on every key input, so the error appears after each keystroke.
+##
+##   https://github.com/akinomyoga/ble.sh/issues/545
+function ble/contrib/integration:bash-completion/apt/patch-function {
+  ble/is-function _apt || return 0
+
+  local lambda=ble/contrib/integration:bash-completion/apt/patch-function:orig
+  ble/is-function "$lambda" && return 0
+
+  local def
+  ble/util/assign def 'declare -f _apt' || return 0
+
+  local old='COMPREPLY=($(apt-cache --no-generate pkgnames "$cur" 2> /dev/null) $(apt-cache dumpavail | command grep "^Source: $cur" | sort -u | cut -f2 -d" "));'
+  local new='COMPREPLY=($({ apt-cache --no-generate pkgnames "$cur" 2> /dev/null; apt-cache dumpavail 2> /dev/null | command grep "^Source: $cur" | sort -u | cut -f2 -d" "; }));'
+  if [[ $def == *"$old"* ]]; then
+    def=${def//"$old"/"$new"}
+  elif [[ $def == *'apt-cache dumpavail |'* && $def != *'apt-cache dumpavail 2>'* ]]; then
+    def=${def//'apt-cache dumpavail |'/'apt-cache dumpavail 2> /dev/null |'}
+  else
+    return 0
+  fi
+
+  ble/function#.copy-primitive _apt "$lambda"
+  builtin eval "$def"
+}
+
 function ble/contrib/integration:bash-completion/adjust {
   ble/is-function _comp_initialize || ble/is-function _quote_readline_by_ref || return 0
 
   ble/contrib/integration:bash-completion/loader/adjust
+
+  [[ $comp_func == _apt ]] &&
+    ble/contrib/integration:bash-completion/apt/patch-function
 
   _ble_contrib_integration_bash_completion_cmd_conditional_sync=(_comp_cmd_make _make _do_dnf5_completion)
 


### PR DESCRIPTION
## Summary

This patch fixes spurious `E: read, still have 1 to read but none left` errors when completing `apt policy`, `apt source`, `apt build-dep`, or `apt showsrc` while using ble.sh.

The companion PR to **ble.sh** (submodule pointer update): https://github.com/akinomyoga/ble.sh/pull/712

Related discussion: https://github.com/akinomyoga/ble.sh/issues/545

## Root cause

Debian/Ubuntu **bash-completion**'s `_apt` function contains this completion logic for `policy|source|build-dep|showsrc`:

```bash
COMPREPLY=($(apt-cache --no-generate pkgnames "$cur" 2> /dev/null) $(apt-cache dumpavail | \
    command grep "^Source: $cur" | sort -u | cut -f2 -d" "))
```

Two problems:

1. **`apt-cache dumpavail` stderr is not redirected.** When stdout is captured by command substitution (as bash-completion does here), `apt-cache dumpavail` writes `E: read, still have 1 to read but none left` to stderr. This is an apt/apt-cache behavior when output is not a TTY.

2. **Adjacent `$(...)` command substitutions** are used where a single grouped substitution would be clearer (though in array assignment context Bash still collects both outputs).

With plain Bash + Readline, users mostly notice this on **Tab**. With **ble.sh auto-complete**, the completion function runs on **every keystroke** after the last space, so the error appears repeatedly while typing a package name.

This is not an apt bug introduced by a recent upgrade; it is triggered by how bash-completion invokes `apt-cache dumpavail`. The issue reporter confirmed it also appears with Tab completion in plain Bash without ble.sh (https://github.com/akinomyoga/ble.sh/issues/545#issuecomment).

## Fix

Patch `_apt` at load time from ble.sh's bash-completion integration:

- Merge the two command substitutions into one `{ ... }` group.
- Redirect `apt-cache dumpavail` stderr to `/dev/null`.
- Fall back to only adding the stderr redirect if the function body differs from the expected pattern (forward compatibility).

## Test plan

- [x] Reproduced the error with `apt policy a` completion before the patch
- [x] Verified the patched `_apt` produces the same candidates without stderr noise
- [x] `make check` passes (ble.sh test suite; pre-existing unrelated locale failures only)

Manual verification after rebuilding/reloading ble.sh:

```bash
make
source out/ble.sh
# Type: apt policy <pkgname>
# Confirm no "E: read, still have 1 to read but none left" after each key
```